### PR TITLE
Switch #cleanup from using redis KEYS to SCAN

### DIFF
--- a/lib/resque_solo/queue.rb
+++ b/lib/resque_solo/queue.rb
@@ -60,8 +60,13 @@ module ResqueSolo
       end
 
       def cleanup(queue)
-        keys = redis.keys("solo:queue:#{queue}:job:*")
-        redis.del(*keys) if keys.any?
+        "0".tap do |cursor|
+          loop do
+            cursor, keys = redis.scan(cursor, match: "solo:queue:#{queue}:job:*")
+            redis.del(*keys) if keys.any?
+            break if cursor.to_i.zero?
+          end
+        end
       end
 
       private


### PR DESCRIPTION
We had a production incident where Redis became blocking and we tracked it back to resque_solo using keys operations.

Using the KEYS is a very expensive operation, and redis docs explicitly warn redis users from using this command, especially in production. As redis is a single thread DB, long operations such as KEYS stop redis from all executions until redis finished processing the command. This operation should be avoided, and it is highly recommended to replace these calls with the SCAN command.